### PR TITLE
Remove core infra checkout step

### DIFF
--- a/.github/workflows/apply-terraform.yml
+++ b/.github/workflows/apply-terraform.yml
@@ -74,14 +74,6 @@ jobs:
     - name: Set global git credentials
       run: git config --global url.https://${{ secrets.AWS_GITHUBRUNNER_PAT }}@github.com/.insteadOf https://github.com/
 
-    - name: Checkout i-ai-core-infrastructure
-      uses: actions/checkout@v4
-      with:
-        repository: i-dot-ai/i-ai-core-infrastructure
-        ref: ${{ inputs.CORE_INFRA_REF }}
-        token: ${{ secrets.AWS_GITHUBRUNNER_PAT }}
-        path: i-ai-core-infrastructure
-
     - name: Optionally checkout terraform config variables for public repos
       if: ${{ inputs.PUBLIC_INFRA_DEPLOYMENT == true }}
       uses: actions/checkout@v4

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -71,13 +71,6 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           mask-aws-account-id: 'yes'
   
-    - name: Checkout i-dot-ai-core-terraform repo
-      uses: actions/checkout@v4
-      with:
-        repository: i-dot-ai/i-ai-core-infrastructure
-        ref: refs/heads/main
-        token: ${{ secrets.AWS_GITHUBRUNNER_PAT }}
-        path: i-dot-ai-core-terraform
 
     - name: Login to Amazon ECR
       run: |


### PR DESCRIPTION
**Change Log:**

-All core infrastructure modules have been migrated to [this repository](https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules), so the checkout step can now be removed from the workflow.