### PR TITLE
adds an output for aws-account-id on the authenicate aws action

### DIFF
--- a/.github/actions/authenticate-aws/action.yml
+++ b/.github/actions/authenticate-aws/action.yml
@@ -24,6 +24,10 @@ inputs:
     AWS_GITHUBRUNNER_USER_SECRET_ID:
         description: 'AWS secret access key'
         required: false
+outputs:
+  aws-account-id:
+    description: "AWS Account ID"
+    value: ${{ inputs.AWS_ACCOUNT_ID }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
Allows the usage of `${{ steps.aws-auth.outputs.aws-account-id }}` downstream