### PR TITLE
Support changes to deployment role structure

### DIFF
--- a/.github/actions/authenticate-aws/action.yml
+++ b/.github/actions/authenticate-aws/action.yml
@@ -7,7 +7,7 @@ inputs:
         description: 'Env to deploy to'
     APP_NAME:
         required: false
-        description: 'optional flag for the APP Name'
+        description: 'optional flag for the app name, used to override the role name if required'
     USE_OIDC:
         description: "Use OIDC for AWS authentication. Supported values 'true' or 'false'"
         required: false
@@ -43,7 +43,7 @@ runs:
       with:
         aws-region: ${{ inputs.AWS_REGION }}
         mask-aws-account-id: 'yes'
-        role-to-assume: arn:aws:iam::${{ inputs.AWS_ACCOUNT_ID }}:role/infra/${{ github.event.repository.name }}-${{ inputs.ENVIRONMENT }}-github-deployment-role
+        role-to-assume: arn:aws:iam::${{ inputs.AWS_ACCOUNT_ID }}:role/infra/i-dot-ai-${{ inputs.ENVIRONMENT }}-${{ inputs.APP_NAME || github.event.repository.name }}-ci-deployment-role
 
     - name: Check AWS Auth
       shell: bash

--- a/.github/workflows/apply-terraform.yml
+++ b/.github/workflows/apply-terraform.yml
@@ -81,7 +81,7 @@ jobs:
       run: echo "$INPUTS"
 
     - name: AWS Authentication
-      uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@EN-784/deploy_roles_org_prefix
+      uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@main
       with:
         APP_NAME: ${{ inputs.APP_NAME }}
         USE_OIDC: ${{ inputs.USE_OIDC }}

--- a/.github/workflows/apply-terraform.yml
+++ b/.github/workflows/apply-terraform.yml
@@ -83,6 +83,7 @@ jobs:
     - name: AWS Authentication
       uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@EN-784/deploy_roles_org_prefix
       with:
+        APP_NAME: ${{ inputs.APP_NAME }}
         USE_OIDC: ${{ inputs.USE_OIDC }}
         ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
         AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/apply-terraform.yml
+++ b/.github/workflows/apply-terraform.yml
@@ -81,7 +81,7 @@ jobs:
       run: echo "$INPUTS"
 
     - name: AWS Authentication
-      uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@main
+      uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@EN-784/deploy_roles_org_prefix
       with:
         USE_OIDC: ${{ inputs.USE_OIDC }}
         ENVIRONMENT: ${{ inputs.ENVIRONMENT }}

--- a/.github/workflows/start-runner.yml
+++ b/.github/workflows/start-runner.yml
@@ -60,7 +60,7 @@ jobs:
         run: echo "$INPUTS"
 
       - name: AWS Authentication
-        uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@EN-784/deploy_roles_org_prefix
+        uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@main
         with:
           APP_NAME: ${{ inputs.APP_NAME }}
           USE_OIDC: ${{ inputs.USE_OIDC }}

--- a/.github/workflows/start-runner.yml
+++ b/.github/workflows/start-runner.yml
@@ -21,6 +21,9 @@ on:
         required: false
         type: boolean
         default: false
+      APP_NAME:
+        required: false
+        type: string
     secrets:
       AWS_GITHUBRUNNER_USER_ACCESS_KEY:
         required: true
@@ -59,6 +62,7 @@ jobs:
       - name: AWS Authentication
         uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@EN-784/deploy_roles_org_prefix
         with:
+          APP_NAME: ${{ inputs.APP_NAME }}
           USE_OIDC: ${{ inputs.USE_OIDC }}
           ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
           AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/start-runner.yml
+++ b/.github/workflows/start-runner.yml
@@ -57,7 +57,7 @@ jobs:
         run: echo "$INPUTS"
 
       - name: AWS Authentication
-        uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@main
+        uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@EN-784/deploy_roles_org_prefix
         with:
           USE_OIDC: ${{ inputs.USE_OIDC }}
           ENVIRONMENT: ${{ inputs.ENVIRONMENT }}

--- a/.github/workflows/stop-runner.yml
+++ b/.github/workflows/stop-runner.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: AWS Authentication
-        uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@EN-784/deploy_roles_org_prefix
+        uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@main
         with:
           APP_NAME: ${{ inputs.APP_NAME }}
           USE_OIDC: ${{ inputs.USE_OIDC }}

--- a/.github/workflows/stop-runner.yml
+++ b/.github/workflows/stop-runner.yml
@@ -18,6 +18,9 @@ on:
         required: false
         default: prod
         type: string
+      APP_NAME:
+        required: false
+        type: string
     secrets:
       AWS_GITHUBRUNNER_USER_ACCESS_KEY:
         required: true
@@ -37,6 +40,7 @@ jobs:
       - name: AWS Authentication
         uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@EN-784/deploy_roles_org_prefix
         with:
+          APP_NAME: ${{ inputs.APP_NAME }}
           USE_OIDC: ${{ inputs.USE_OIDC }}
           ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
           AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/stop-runner.yml
+++ b/.github/workflows/stop-runner.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: AWS Authentication
-        uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@main
+        uses: i-dot-ai/i-dot-ai-core-github-actions/.github/actions/authenticate-aws@EN-784/deploy_roles_org_prefix
         with:
           USE_OIDC: ${{ inputs.USE_OIDC }}
           ENVIRONMENT: ${{ inputs.ENVIRONMENT }}


### PR DESCRIPTION
Supports the new deployment roles, where all roles are prefixed with `i-dot-ai` and any `i-dot-ai` prefix on the repository name is being removed.

`APP_NAME` can now be passed to override the repo name, allowing for repos like `i-dot-ai-cookiecutter` to remove the org prefix and assume the role correctly