### PR TITLE
allow for git status porcelain non-zero exit code

### DIFF
--- a/.github/workflows/cruft-update-repo.yml
+++ b/.github/workflows/cruft-update-repo.yml
@@ -119,10 +119,11 @@ jobs:
       - name: Handle rejection files 
         if: steps.check.outputs.has_changes == '1'
         run: |
+          set +e
+
           rejected_file_list=$(git status --porcelain | sed s/^...// | grep .rej)
           errored_files=()
 
-          set +e
           for rej_file in $rejected_file_list; do
             original_file=$(echo $rej_file | sed 's/\.rej$//')
 


### PR DESCRIPTION
The command to get any .rej files is failing if there's not a match, due to grep returning a non-zero exit code.

As we can allow for this command to fail, I'm moving the `set +e` declaration above it.