### PR TITLE
Change from pipe and tee for writing to the terraform log

### DIFF
--- a/.github/workflows/apply-ip-config.yml
+++ b/.github/workflows/apply-ip-config.yml
@@ -82,9 +82,9 @@ jobs:
       run: |
         cd main
         if [[ "$INSTANCE" == "universal" ]]; then
-          make tf_auto_apply instance=$INSTANCE  | tee tf_apply_log.log
+          make tf_auto_apply instance=$INSTANCE  > tf_apply_log.log
         else
-          make tf_auto_apply instance=infra env=$INSTANCE | tee tf_apply_log.log
+          make tf_auto_apply instance=infra env=$INSTANCE > tf_apply_log.log
         fi
 
     - name: Copy terraform logs to s3


### PR DESCRIPTION
Send the output directly to a log in the same command, rather than using a | and `tee` which is likely causing errors to not be handled on the `terraform apply` command