### PR TITLE
Fix usage reference on Claude PR to use inputs and not secrets

### DIFF
--- a/.github/actions/claude-review/action.yml
+++ b/.github/actions/claude-review/action.yml
@@ -33,11 +33,11 @@ runs:
         MODEL: ${{ inputs.MODEL }}
         CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: 1
       with:
-        anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        anthropic_api_key: ${{ inputs.ANTHROPIC_API_KEY }}
         timeout_minutes: ${{ inputs.TIMEOUT_DURATION }}
         show_full_output: false
         claude_args: "--model ${{ env.MODEL }} "
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ inputs.GITHUB_TOKEN }}
         track_progress: true
         allowed_bots: aikido-autofix
         prompt: |


### PR DESCRIPTION
Should resolve the following error:
```
The template is not valid. i-dot-ai/i-dot-ai-core-github-actions/main/.github/actions/claude-review/action.yml (Line: 36, Col: 28): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.ANTHROPIC_API_KEY,i-dot-ai/i-dot-ai-core-github-actions/main/.github/actions/claude-review/action.yml (Line: 40, Col: 23): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.GITHUB_TOKEN
```

The secrets should still be masked on the workflow execution, so long as they're still used as secrets in the downstream workflow. 